### PR TITLE
Iterator version of impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["encoding"]
 exclude = [".gitignore"]
 
 [dependencies]
+itertools = { version = "0.10.5" }
 thiserror = { version = "1.0.37", default-features = false }
 
 [dev-dependencies]
@@ -22,3 +23,6 @@ rand = "0.8.5"
 [[bench]]
 name = "encode"
 harness = false
+
+[profile.release]
+lto = true

--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -15,7 +15,7 @@ fn encode_benchmark(c: &mut Criterion) {
 
     c.bench_function("decoder", |b| {
         b.iter(|| {
-            let _ = decode(black_box(&encoded));
+            let _ = decode(black_box(encoded.bytes()));
         })
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,200 +24,111 @@ pub enum Error {
     InvalidCharacter(u8),
 }
 
-#[inline]
-fn byte_to_char85(x85: u8) -> u8 {
-    static B85_TO_CHAR: &'static [u8] =
-        b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+-;<=>?@^_`{|}~";
-    B85_TO_CHAR[x85 as usize]
-}
-
-#[inline]
-fn char85_to_byte(c: u8) -> Result<u8> {
-    match c {
-        b'0'..=b'9' => Ok(c - b'0'),
-        b'A'..=b'Z' => Ok(c - b'A' + 10),
-        b'a'..=b'z' => Ok(c - b'a' + 36),
-        b'!' => Ok(62),
-        b'#' => Ok(63),
-        b'$' => Ok(64),
-        b'%' => Ok(65),
-        b'&' => Ok(66),
-        b'(' => Ok(67),
-        b')' => Ok(68),
-        b'*' => Ok(69),
-        b'+' => Ok(70),
-        b'-' => Ok(71),
-        b';' => Ok(72),
-        b'<' => Ok(73),
-        b'=' => Ok(74),
-        b'>' => Ok(75),
-        b'?' => Ok(76),
-        b'@' => Ok(77),
-        b'^' => Ok(78),
-        b'_' => Ok(79),
-        b'`' => Ok(80),
-        b'{' => Ok(81),
-        b'|' => Ok(82),
-        b'}' => Ok(83),
-        b'~' => Ok(84),
-        v => Err(Error::InvalidCharacter(v)),
-    }
-}
+use itertools::Itertools;
+use core::borrow::Borrow;
 
 /// encode() turns a slice of bytes into a string of encoded data
-pub fn encode(indata: &[u8]) -> String {
-    if indata.len() == 0 {
-        return String::from("");
+pub fn encode(indata: impl IntoIterator<Item=impl Borrow<u8>>) -> String {
+    #[inline]
+    fn byte_to_char85(x85: u8) -> u8 {
+        unsafe { *b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+-;<=>?@^_`{|}~".get_unchecked(x85 as usize) }
     }
 
-    let mut outdata: Vec<u8> = Vec::new();
+    let mut v = Vec::<u8>::new();
 
-    let length = indata.len();
-    let chunk_count = (length / 4) as u32;
-    let mut data_index: usize = 0;
-
-    for _i in 0..chunk_count {
-        let decnum: u32 = (indata[data_index] as u32).overflowing_shl(24).0
-            | (indata[data_index + 1] as u32).overflowing_shl(16).0
-            | (indata[data_index + 2] as u32).overflowing_shl(8).0
-            | indata[data_index + 3] as u32;
-
-        outdata.push(byte_to_char85((decnum as usize / 52200625) as u8));
-        let mut remainder = decnum as usize % 52200625;
-        outdata.push(byte_to_char85((remainder / 614125) as u8));
-
-        remainder %= 614125;
-        outdata.push(byte_to_char85((remainder / 7225) as u8));
-
-        remainder %= 7225;
-        outdata.push(byte_to_char85((remainder / 85) as u8));
-
-        outdata.push(byte_to_char85((remainder % 85) as u8));
-
-        data_index += 4;
-    }
-
-    let extra_bytes = length % 4;
-    if extra_bytes != 0 {
-        let mut last_chunk = 0_u32;
-
-        for i in length - extra_bytes..length {
-            last_chunk = last_chunk.overflowing_shl(8).0;
-            last_chunk |= indata[i] as u32;
-        }
-
-        // Pad extra bytes with zeroes
-        {
-            let mut i = 4 - extra_bytes;
-            while i > 0 {
-                last_chunk = last_chunk.overflowing_shl(8).0;
-                i -= 1;
-            }
-        }
-
-        outdata.push(byte_to_char85((last_chunk as usize / 52200625) as u8));
-        let mut remainder = last_chunk as usize % 52200625;
-        outdata.push(byte_to_char85((remainder / 614125) as u8));
-
-        if extra_bytes > 1 {
-            remainder %= 614125;
-            outdata.push(byte_to_char85((remainder / 7225) as u8));
-
-            if extra_bytes > 2 {
-                remainder %= 7225;
-                outdata.push(byte_to_char85((remainder / 85) as u8));
+    let mut id = indata.into_iter();
+    loop {
+        match (id.next().map(|x|*x.borrow()), id.next().map(|x|*x.borrow()), id.next().map(|x|*x.borrow()), id.next().map(|x|*x.borrow())) {
+            (Some(a),Some(b),Some(c),Some(d)) => {
+                let decnum = u32::from_be_bytes([a, b, c, d]);
+                v.extend([
+                    byte_to_char85((decnum / 85u32.pow(4)) as u8),
+                    byte_to_char85(((decnum % 85u32.pow(4)) / 85u32.pow(3)) as u8),
+                    byte_to_char85(((decnum % 85u32.pow(3)) / 85u32.pow(2)) as u8),
+                    byte_to_char85(((decnum % 85u32.pow(2)) / 85u32) as u8),
+                    byte_to_char85((decnum % 85u32) as u8)
+                ]);
+            },
+            (Some(a),b,c,d) => {
+                let decnum = u32::from_be_bytes([a, b.unwrap_or(0), c.unwrap_or(0), d.unwrap_or(0)]);
+                v.push(byte_to_char85((decnum / 85u32.pow(4)) as u8));
+                v.push(byte_to_char85(((decnum % 85u32.pow(4)) / 85u32.pow(3)) as u8));
+                if b.is_some() {
+                    v.push(byte_to_char85(((decnum % 85u32.pow(3)) / 85u32.pow(2)) as u8));
+                }
+                if c.is_some() {
+                    v.push(byte_to_char85(((decnum % 85u32.pow(2)) / 85u32) as u8));
+                }
+                if d.is_some() {
+                    v.push(byte_to_char85((decnum % 85u32) as u8));
+                }
+            },
+            (None, _, _, _) => {
+                break;
             }
         }
     }
 
-    String::from_utf8(outdata).unwrap()
+    unsafe { String::from_utf8_unchecked(v) }
 }
 
-/// decode() turns a string of encoded data into a slice of bytes
-pub fn decode(instr: &str) -> Result<Vec<u8>> {
-    let length = instr.len() as u32;
-    let mut outdata = Vec::<u8>::new();
-    let mut accumulator;
-    let mut in_index = instr.bytes();
-
-    for _chunk in 0..length / 5 {
-        accumulator = 0;
-
-        // This construct is a bit strange because Rust doesn't let us modify the index variable
-        // in a for loop
-        {
-            let mut i = 0;
-            while i < 5 {
-                let b = match in_index.next() {
-                    Some(n) => n,
-                    _ => break,
-                };
-                match b {
-                    32 | 10 | 11 | 13 => {
-                        // Ignore whitespace
-                        continue;
-                    }
-                    _ => {}
-                }
-
-                accumulator = (accumulator * 85) + char85_to_byte(b)? as u32;
-                i += 1;
-            }
-        }
-        outdata.push((accumulator >> 24) as u8);
-        outdata.push(((accumulator >> 16) & 255) as u8);
-        outdata.push(((accumulator >> 8) & 255) as u8);
-        outdata.push((accumulator & 255) as u8);
-    }
-
-    let remainder = length % 5;
-    if remainder > 0 {
-        accumulator = 0;
-        {
-            let mut i = 0;
-            while i < 5 {
-                let value: u8;
-
-                if i < remainder {
-                    let b = match in_index.next() {
-                        Some(n) => n,
-                        _ => break,
-                    };
-                    match b {
-                        32 | 10 | 11 | 13 => {
-                            // Ignore whitespace
-                            continue;
-                        }
-                        _ => {}
-                    }
-
-                    value = char85_to_byte(b)?;
-                } else {
-                    value = 126;
-                }
-                accumulator = (accumulator * 85) + value as u32;
-                i += 1;
-            }
-        }
-
-        match remainder {
-            4 => {
-                outdata.push((accumulator >> 24) as u8);
-                outdata.push(((accumulator >> 16) & 255) as u8);
-                outdata.push(((accumulator >> 8) & 255) as u8);
-            }
-            3 => {
-                outdata.push((accumulator >> 24) as u8);
-                outdata.push(((accumulator >> 16) & 255) as u8);
-            }
-            2 => {
-                outdata.push((accumulator >> 24) as u8);
-            }
-            _ => panic!(),
+pub fn decode(indata: impl IntoIterator<Item=impl Borrow<u8>>) -> Result<Vec<u8>> {
+    #[inline]
+    fn char85_to_byte(c: u8) -> Result<u8> {
+        match c {
+            b'0'..=b'9' => Ok(c - b'0'),
+            b'A'..=b'Z' => Ok(c - b'A' + 10),
+            b'a'..=b'z' => Ok(c - b'a' + 36),
+            b'!' => Ok(62),
+            b'#' => Ok(63),
+            b'$' => Ok(64),
+            b'%' => Ok(65),
+            b'&' => Ok(66),
+            b'(' => Ok(67),
+            b')' => Ok(68),
+            b'*' => Ok(69),
+            b'+' => Ok(70),
+            b'-' => Ok(71),
+            b';' => Ok(72),
+            b'<' => Ok(73),
+            b'=' => Ok(74),
+            b'>' => Ok(75),
+            b'?' => Ok(76),
+            b'@' => Ok(77),
+            b'^' => Ok(78),
+            b'_' => Ok(79),
+            b'`' => Ok(80),
+            b'{' => Ok(81),
+            b'|' => Ok(82),
+            b'}' => Ok(83),
+            b'~' => Ok(84),
+            v => Err(Error::InvalidCharacter(v)),
         }
     }
 
-    Ok(outdata)
+    indata
+        .into_iter()
+        .map(|v|*v.borrow())
+        .filter(|v| !(*v == 32 || *v == 10 || *v == 11 || *v == 13))
+        .chunks(5)
+        .into_iter()
+        .map(|mut v| {
+            let (a,b,c,d,e) = (v.next(), v.next(), v.next(), v.next(), v.next());
+            let accumulator = u32::from(char85_to_byte(a.unwrap())?) * 85u32.pow(4)
+                + u32::from(b.map_or(Err(Error::UnexpectedEof), char85_to_byte)?) * 85u32.pow(3)
+                + u32::from(c.map_or(Ok(126), char85_to_byte)?) * 85u32.pow(2)
+                + u32::from(d.map_or(Ok(126), char85_to_byte)?) * 85u32.pow(1)
+                + u32::from(e.map_or(Ok(126), char85_to_byte)?) * 85u32.pow(0);
+            Ok([
+                Some((accumulator >> 24) as u8),
+                c.map(|_|(accumulator >> 16) as u8),
+                d.map(|_|(accumulator >> 8) as u8),
+                e.map(|_|accumulator as u8)
+            ])
+        })
+        .flatten_ok()
+        .filter_map_ok(|v| v)
+        .collect::<Result<Vec<u8>>>()
 }
 
 #[cfg(test)]
@@ -244,11 +155,11 @@ mod tests {
             let s = encode(test.0.as_bytes());
             assert_eq!(
                 s, test.1,
-                "encoder test failed: wanted: {}, got: {}",
-                test.0, s
+                "encoder test {} failed: wanted: {}, got: {}",
+                test.0, test.1, s
             );
 
-            let b = decode(test.1)
+            let b = decode(test.1.bytes())
                 .unwrap_or_else(|e| panic!("decoder test error on input {}: {}", test.1, e));
 
             let s = String::from_utf8(b).unwrap_or_else(|e| {


### PR DESCRIPTION
**Overview**

This implements the encode/decode functions with iterators. It also returns a `Result` if `decode` encounters a stream with invalid characters, rather than panicking, which is extremely undesirable. For instance, a GUI application reading a user-supplied text file would appear to just crash.

This is at best a WIP PR, but maybe just a grab bag. The only thing I'd say is really pretty important is returning a `Result` rather than panicking if the incoming data has unexpected characters in it.

**Panicking**

I tried to be very careful about where to use panicking. I left a few in - specifically in the `encode` function. These could probably be `.get_unchecked` (for the array access) and `String::from_ut8_unchecked` as the modulo-85 ensures that it's "impossible" (neglecting the possibility of single-bit flips due to cosmic rays or other shennanigans!) for larger indices or non-ASCII characters to be generated. My hope would be that the compiler would realize this and optimize the checks and potential panics out; if not, I would go ahead and use the `_unchecked` variants. The main reason to leave the checked variants in is if some code refactoring accidentally breaks these assumptions, they will fail very loudly. But for larger datasets especially, they might have a significant performance burden if the compiler does not optimize out the checks.

I think the `base64` crate even goes to the length of defining its own enum representing a subset of ASCII characters, I did not feel the benefits I was aware of for this approach would outweigh the extra code and types it would require.

**Optimizing**

This is probably not the ideally performant version, although the fact that the generics will get instantiated for specific types will hopefully be sufficient for the compiler to understand any benefits it can if the data source provided is consecutive. Ideally, the compiler would figure out you can unroll the loop slightly, but that may be too much of a stretch. Figuring out how to tweak the implementation for optimal performance would probably require a larger dataset and use of `criterion`.

If there are known, larger cases I would definitely test this on those to see if there's a performance regression (or improvement) before merging it in.

**impl Read**

I would also consider using `impl Read` rather than iterators, although this could also be a separate type, as the `base64` crate does it.

**no_std**

Finally this depends on `itertools` due to use of the `chunks` function. There may be a better alternative implementation - I don't like that itertools introduces an implicit dependency on `std`. I think it would be ideal if this crate could be compatible with `no_std`, though this would also mean changing `String` as the return type. I'm not sure if you could collect to an array somehow, so this might alter the function interface entirely to take a `&mut [u8]` in `#[no_std]` contexts.