### PR TITLE
Stop overflowing the stack in `encode_benchmark`

### DIFF
--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -3,7 +3,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::RngCore;
 
 fn encode_benchmark(c: &mut Criterion) {
-    let mut testdata = [0; 0x100000];
+    let mut testdata = vec![0; 0x100000];
     rand::thread_rng().fill_bytes(&mut testdata);
     let encoded = encode(&testdata);
 


### PR DESCRIPTION
Without this I get
```text
C:\src\base85>cargo +nightly bench --bench encode
    Finished bench [optimized] target(s) in 0.09s
     Running benches\encode.rs (target\release\deps\encode-f0c1f0afa4ad4dcc.exe)

thread 'main' has overflowed its stack
error: bench failed, to rerun pass `--bench encode`

Caused by:
  process didn't exit successfully: `C:\src\base85\target\release\deps\encode-f0c1f0afa4ad4dcc.exe --bench` (exit code: 0xc00000fd, STATUS_STACK_OVERFLOW)
```