### PR TITLE
Add more encoder benchmarks

### DIFF
--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -13,6 +13,18 @@ fn encode_benchmark(c: &mut Criterion) {
         })
     });
 
+    c.bench_function("encoder_prime", |b| {
+        b.iter(|| {
+            let _ = encode(black_box(&testdata[..100003]));
+        })
+    });
+
+    c.bench_function("encoder_short", |b| {
+        b.iter(|| {
+            let _ = encode(black_box(&testdata[..11]));
+        })
+    });
+
     c.bench_function("decoder", |b| {
         b.iter(|| {
             let _ = decode(black_box(&encoded));


### PR DESCRIPTION
The existing one is length 0x100000, which is a large power of two.  So this adds one with a prime length that will hit the edge cases, as well as a short one for when essentially all the data is in cache.