### PR TITLE
Slightly faster decode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@
 //!
 //! Even though I've been coding for a while and have learned quite a bit about Rust, but I'm still a novice. Suggestions and contributions are always welcome and appreciated.
 
+use core::mem::MaybeUninit;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(thiserror::Error, Debug)]
@@ -135,89 +137,50 @@ pub fn encode(indata: &[u8]) -> String {
 
 /// decode() turns a string of encoded data into a slice of bytes
 pub fn decode(instr: &str) -> Result<Vec<u8>> {
-    let length = instr.len() as u32;
-    let mut outdata = Vec::<u8>::new();
-    let mut accumulator;
-    let mut in_index = instr.bytes();
+    let indata = instr.as_bytes();
+    let chunks = indata.chunks_exact(5);
+    let remainder = chunks.remainder();
+    let capacity = if remainder.is_empty() { (indata.len()/5)*4 } else { (indata.len()/5)*4 + remainder.len()-1 };
+    let mut out = Vec::<MaybeUninit<u8>>::with_capacity(capacity);
+    unsafe { out.set_len(capacity); }
+    let mut out_chunks = out.chunks_exact_mut(4);
 
-    for _chunk in 0..length / 5 {
-        accumulator = 0;
-
-        // This construct is a bit strange because Rust doesn't let us modify the index variable
-        // in a for loop
-        {
-            let mut i = 0;
-            while i < 5 {
-                let b = match in_index.next() {
-                    Some(n) => n,
-                    _ => break,
-                };
-                match b {
-                    32 | 10 | 11 | 13 => {
-                        // Ignore whitespace
-                        continue;
-                    }
-                    _ => {}
-                }
-
-                accumulator = (accumulator * 85) + char85_to_byte(b)? as u32;
-                i += 1;
-            }
-        }
-        outdata.push((accumulator >> 24) as u8);
-        outdata.push(((accumulator >> 16) & 255) as u8);
-        outdata.push(((accumulator >> 8) & 255) as u8);
-        outdata.push((accumulator & 255) as u8);
+    for (chunk, out_chunk) in std::iter::zip(chunks, &mut out_chunks) {
+        let accumulator = u32::from(char85_to_byte(chunk[0])?) * 85u32.pow(4)
+            + u32::from(char85_to_byte(chunk[1])?) * 85u32.pow(3)
+            + u32::from(char85_to_byte(chunk[2])?) * 85u32.pow(2)
+            + u32::from(char85_to_byte(chunk[3])?) * 85u32
+            + u32::from(char85_to_byte(chunk[4])?);
+        out_chunk[0] = MaybeUninit::new((accumulator >> 24) as u8);
+        out_chunk[1] = MaybeUninit::new((accumulator >> 16) as u8);
+        out_chunk[2] = MaybeUninit::new((accumulator >> 8) as u8);
+        out_chunk[3] = MaybeUninit::new(accumulator as u8);
     }
 
-    let remainder = length % 5;
-    if remainder > 0 {
-        accumulator = 0;
-        {
-            let mut i = 0;
-            while i < 5 {
-                let value: u8;
-
-                if i < remainder {
-                    let b = match in_index.next() {
-                        Some(n) => n,
-                        _ => break,
-                    };
-                    match b {
-                        32 | 10 | 11 | 13 => {
-                            // Ignore whitespace
-                            continue;
-                        }
-                        _ => {}
-                    }
-
-                    value = char85_to_byte(b)?;
-                } else {
-                    value = 126;
+    let out_remainder = out_chunks.into_remainder();
+    if let Some(a) = remainder.first().copied() {
+        let b = remainder.get(1).copied();
+        let c = remainder.get(2).copied();
+        let d = remainder.get(3).copied();
+        let e = remainder.get(4).copied();
+        let accumulator = u32::from(char85_to_byte(a)?) * 85u32.pow(4)
+            + u32::from(b.map_or(Err(Error::UnexpectedEof), char85_to_byte)?) * 85u32.pow(3)
+            + u32::from(c.map_or(Ok(126), char85_to_byte)?) * 85u32.pow(2)
+            + u32::from(d.map_or(Ok(126), char85_to_byte)?) * 85u32.pow(1)
+            + u32::from(e.map_or(Ok(126), char85_to_byte)?) * 85u32.pow(0);
+        out_remainder[0] = MaybeUninit::new((accumulator >> 24) as u8);
+        if remainder.len() > 2 {
+            out_remainder[1] = MaybeUninit::new((accumulator >> 16) as u8);
+            if remainder.len() > 3 {
+                out_remainder[2] = MaybeUninit::new((accumulator >> 8) as u8);
+                if remainder.len() > 4 {
+                    out_remainder[3] = MaybeUninit::new(accumulator as u8);
                 }
-                accumulator = (accumulator * 85) + value as u32;
-                i += 1;
             }
-        }
-
-        match remainder {
-            4 => {
-                outdata.push((accumulator >> 24) as u8);
-                outdata.push(((accumulator >> 16) & 255) as u8);
-                outdata.push(((accumulator >> 8) & 255) as u8);
-            }
-            3 => {
-                outdata.push((accumulator >> 24) as u8);
-                outdata.push(((accumulator >> 16) & 255) as u8);
-            }
-            2 => {
-                outdata.push((accumulator >> 24) as u8);
-            }
-            _ => panic!(),
         }
     }
 
-    Ok(outdata)
+    Ok(unsafe { std::mem::transmute::<_, Vec<u8>>(out) } )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This uses the same pattern as my faster encode. It only shows as 10% faster. My hunch is that the conditionals are what's eating a lot of the time. Unfortunately I haven't thought up any clever non-SIMD tricks for reducing them.

You can replace the outdata assignments in the kernel with this:
```
unsafe { out_chunk.align_to_mut::<u32>().1[0]  = accumulator };
```

but it didn't yield meaningfully increased performance for me and adds an unsafe usage.