### PR TITLE
Fix integer overflow when decoding out-of-range Base85 groups

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub enum Error {
     UnexpectedEof,
     #[error("Unexpected character '{0}'")]
     InvalidCharacter(u8),
+    #[error("Group is out of range for valid Base85 (exceeds u32::MAX)")]
+    Overflow,
 }
 
 #[inline]
@@ -138,11 +140,17 @@ pub fn decode(instr: &str) -> Result<Vec<u8>> {
     let mut out_chunks = out.chunks_exact_mut(4);
 
     for (chunk, out_chunk) in std::iter::zip(chunks, &mut out_chunks) {
-        let accumulator = u32::from(char85_to_byte(chunk[0])?) * 85u32.pow(4)
-            + u32::from(char85_to_byte(chunk[1])?) * 85u32.pow(3)
-            + u32::from(char85_to_byte(chunk[2])?) * 85u32.pow(2)
-            + u32::from(char85_to_byte(chunk[3])?) * 85u32
-            + u32::from(char85_to_byte(chunk[4])?);
+        // A 5-character group can reach 84 * (85^4 + ... + 1) = 4_437_053_124, past
+        // u32::MAX, so accumulate in u64 and reject groups that don't fit in four bytes.
+        let accumulator = u64::from(char85_to_byte(chunk[0])?) * 85u64.pow(4)
+            + u64::from(char85_to_byte(chunk[1])?) * 85u64.pow(3)
+            + u64::from(char85_to_byte(chunk[2])?) * 85u64.pow(2)
+            + u64::from(char85_to_byte(chunk[3])?) * 85u64
+            + u64::from(char85_to_byte(chunk[4])?);
+        if accumulator > u64::from(u32::MAX) {
+            return Err(Error::Overflow);
+        }
+        let accumulator = accumulator as u32;
         out_chunk[0] = MaybeUninit::new((accumulator >> 24) as u8);
         out_chunk[1] = MaybeUninit::new((accumulator >> 16) as u8);
         out_chunk[2] = MaybeUninit::new((accumulator >> 8) as u8);
@@ -155,11 +163,15 @@ pub fn decode(instr: &str) -> Result<Vec<u8>> {
         let c = remainder.get(2).copied();
         let d = remainder.get(3).copied();
         let e = remainder.get(4).copied();
-        let accumulator = u32::from(char85_to_byte(a)?) * 85u32.pow(4)
-            + u32::from(b.map_or(Err(Error::UnexpectedEof), char85_to_byte)?) * 85u32.pow(3)
-            + u32::from(c.map_or(Ok(126), char85_to_byte)?) * 85u32.pow(2)
-            + u32::from(d.map_or(Ok(126), char85_to_byte)?) * 85u32.pow(1)
-            + u32::from(e.map_or(Ok(126), char85_to_byte)?) * 85u32.pow(0);
+        let accumulator = u64::from(char85_to_byte(a)?) * 85u64.pow(4)
+            + u64::from(b.map_or(Err(Error::UnexpectedEof), char85_to_byte)?) * 85u64.pow(3)
+            + u64::from(c.map_or(Ok(126), char85_to_byte)?) * 85u64.pow(2)
+            + u64::from(d.map_or(Ok(126), char85_to_byte)?) * 85u64.pow(1)
+            + u64::from(e.map_or(Ok(126), char85_to_byte)?) * 85u64.pow(0);
+        if accumulator > u64::from(u32::MAX) {
+            return Err(Error::Overflow);
+        }
+        let accumulator = accumulator as u32;
         out_remainder[0] = MaybeUninit::new((accumulator >> 24) as u8);
         if remainder.len() > 2 {
             out_remainder[1] = MaybeUninit::new((accumulator >> 16) as u8);
@@ -219,5 +231,25 @@ mod tests {
                 test.0, s
             );
         }
+    }
+
+    #[test]
+    fn test_overflow_groups_return_error() {
+        // Five '~' (84 each) accumulate to 4_437_053_124, past u32::MAX: this panicked
+        // in debug and produced wrong bytes in release before the fix.
+        assert!(matches!(decode("~~~~~"), Err(Error::Overflow)));
+
+        // Same overflow in the trailing-remainder block: "~~" reaches 4_384_852_500.
+        assert!(matches!(decode("~~"), Err(Error::Overflow)));
+
+        // A lone character is an incomplete group: it must still return UnexpectedEof
+        // rather than panicking on the overflowing multiply first.
+        assert!(matches!(decode("}"), Err(Error::UnexpectedEof)));
+
+        // Values right up to the u32 ceiling must still round-trip unchanged.
+        let max = encode(&[0xFF, 0xFF, 0xFF, 0xFF]);
+        assert_eq!(decode(&max).unwrap(), vec![0xFF, 0xFF, 0xFF, 0xFF]);
+        let one = encode(&[0xFF]);
+        assert_eq!(decode(&one).unwrap(), vec![0xFF]);
     }
 }


### PR DESCRIPTION
`decode` accumulates each 5-character group into a `u32`, but a group can reach `84 * (85^4 + 85^3 + 85^2 + 85 + 1) = 4_437_053_124`, which is larger than `u32::MAX`. Inputs that hit this panic in debug (`attempt to multiply with overflow`) and silently produce wrong bytes in release. Both the main loop and the trailing-remainder block are affected.

```text
base85::decode("~~~~~"); // debug: panics at src/lib.rs:141; release: Ok([8, 120, 14, 196])
base85::decode("}");     // debug: panics at src/lib.rs:158
```

This accumulates in `u64` and returns a new `Error::Overflow` for any group whose value can't fit in four bytes. Valid input is unaffected — every in-range group decodes exactly as before, including the `u32::MAX` boundary (`"|NsC0"` → `[255, 255, 255, 255]`). A single trailing character still returns the existing `UnexpectedEof`.

Added a regression test covering both overflow sites and the boundary round-trip. `cargo test` and `cargo fmt --check` pass.

One note: `Error::Overflow` is a new variant on a public enum, so depending on how you treat the API this may warrant a minor or major version bump — your call.

Fixes #7, fixes #9. The diagnosis and the `u64` + reject-out-of-range approach are @7Hugo7's from #9; I put the patch together since one hadn't been opened yet — happy to step aside if they'd rather submit it.
